### PR TITLE
fix(ros-tracing): add python3-bt2

### DIFF
--- a/ansible/roles/ros-tracing/tasks/main.yml
+++ b/ansible/roles/ros-tracing/tasks/main.yml
@@ -10,6 +10,7 @@
       - python3-rosdep
       - python3-setuptools
       - python3-vcstool
+      - python3-bt2
       - wget
   become: true
 


### PR DESCRIPTION
I'd like to merge this change because python3-bt2 is required for current version of CARET.