### PR TITLE
chore: add dependency to repos for Github actions

### DIFF
--- a/caret.repos
+++ b/caret.repos
@@ -27,3 +27,8 @@ repositories:
     type: git
     url: https://github.com/tier4/ros2caret.git
     version: main
+  # Dependency for CI/CD
+  CARET/caret_common:
+    type: git
+    url: https://github.com/autowarefoundation/caret_common.git
+    version: main


### PR DESCRIPTION
Signed-off-by: Takayuki AKAMINE <takayuki.akamine@tier4.jp>

@hsgwa  
I added new depended repository, caret_common, to caret.repos.

Could you check if this change is acceptable as follows? Best,
```
sudo docker run -it --rm --name caret_test ros:galactic
root@ adduser autoware
root@ apt update && apt install -y vim
root@ visudo # add autoware to sudoer
root@ su autoware
$ cd
$ git clone -b add-caret-common-to-repos https://github.com/tier4/caret.git ros2_caret
$ cd ros2_caret
$ mkdir src
$ vcs import src < caret.repos
$ ./setup_caret.sh


```