### PR TITLE
chore(dict): add babeltrace

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,5 +1,6 @@
 {
   "words": [
+    "babeltrace",
     "binsize",
     "cpuid",
     "dataframe",


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

It seems that yaml check was overlooked.
Especially, patch with modifyng github wokflow gets an error.
https://github.com/tier4/CARET_analyze/actions/runs/3125083046/jobs/5069092898

This PR adds "babeltrace" word to local dictionary.
