### PR TITLE
fix: setup for Galactic

### DIFF
--- a/ansible/roles/caret/tasks/main.yml
+++ b/ansible/roles/caret/tasks/main.yml
@@ -16,12 +16,12 @@
   become: true
 
 - name: ROS2 (update rosdep)
-  command: rosdep update
+  command: rosdep update --include-eol-distros
   become: false
 
 - name: caret (rosdep install dependencies)
   shell: |
-    rosdep install -y --from-paths src --ignore-src --rosdistro {{ rosdistro }} -y --skip-keys "{{ targeted_skip_keys }}"
+    rosdep install -y -v --from-paths src --ignore-src --rosdistro {{ rosdistro }} -y --skip-keys "{{ targeted_skip_keys }}"
   args:
     chdir: "{{ WORKSPACE_ROOT }}"
 

--- a/ansible/roles/lttng/tasks/main.yml
+++ b/ansible/roles/lttng/tasks/main.yml
@@ -8,7 +8,6 @@
   apt:
     name:
       - lttng-tools
-      - lttng-modules-dkms
       - liblttng-ust-dev
   become: true
 

--- a/caret.repos
+++ b/caret.repos
@@ -2,19 +2,19 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: galactic
+    version: 47753122084d9762e570761af95c5e123ececf37
   ros2/rclcpp:
     type: git
     url: https://github.com/tier4/rclcpp.git
-    version: galactic_tracepoint_added
+    version: 38481770db16bccc3c6b49f2ff482cfd21889d19
   ros-tracing/ros2_tracing:
     type: git
     url: https://github.com/tier4/ros2_tracing.git
-    version: galactic_tracepoint_added
+    version: 2cd9d104664b4bf4d7507d01e5553129eefe1c9a
   CARET/CARET_trace:
     type: git
     url: https://github.com/tier4/CARET_trace.git
-    version: main
+    version: v0.2.3
   CARET/CARET_analyze:
     type: git
     url: https://github.com/tier4/CARET_analyze.git

--- a/caret.repos
+++ b/caret.repos
@@ -26,7 +26,7 @@ repositories:
   CARET/ros2caret:
     type: git
     url: https://github.com/tier4/ros2caret.git
-    version: main
+    version: v0.3.1
   # Dependency for CI/CD
   CARET/caret_common:
     type: git


### PR DESCRIPTION
## Description
- ROS2 Galactic becomes end-of-life, and packages for Galactic is not installed by default. It causes error at `./setup_caret.sh`
- This PR adds `rosdep install` option to include end-of-life distributions

## Related links

https://github.com/ros/rosdistro/pull/35599

## Notes for reviewers

- This is only for `galactic` branch
- We may stop supporting Galactic when another problem happens in the future


## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
