### PR TITLE
fix: setup for Galactic

### DIFF
--- a/ansible/roles/caret/tasks/main.yml
+++ b/ansible/roles/caret/tasks/main.yml
@@ -16,12 +16,12 @@
   become: true
 
 - name: ROS2 (update rosdep)
-  command: rosdep update
+  command: rosdep update --include-eol-distros
   become: false
 
 - name: caret (rosdep install dependencies)
   shell: |
-    rosdep install -y --from-paths src --ignore-src --rosdistro {{ rosdistro }} -y --skip-keys "{{ targeted_skip_keys }}"
+    rosdep install -y -v --from-paths src --ignore-src --rosdistro {{ rosdistro }} -y --skip-keys "{{ targeted_skip_keys }}"
   args:
     chdir: "{{ WORKSPACE_ROOT }}"
 


### PR DESCRIPTION
## Description
- ROS2 Galactic becomes end-of-life, and packages for Galactic is not installed by default. It causes error at `./setup_caret.sh`
- This PR adds `rosdep install` option to include end-of-life distributions

## Related links

https://github.com/ros/rosdistro/pull/35599

## Notes for reviewers

- This is only for `galactic` branch
- We may stop supporting Galactic when another problem happens in the future
- Spell check error happens. It's probably because dictionary settings is not included in `galactic` branch. I think we can ignore this error for now

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
