### PR TITLE
docs: fix link to community guideline in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 
 ## Pre-review checklist for the PR author
 
-- [ ] I've confirmed the [contribution guidelines].
+- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
 - [ ] The PR is ready for review.
 
 ## In-review checklist for the PR reviewers


### PR DESCRIPTION
Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

## Description

- This PR fixes link to the community guideline in PR template which was added by https://github.com/tier4/caret/pull/57


## Related links

https://github.com/tier4/caret/pull/57

## Notes for reviewers


## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines].
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
