### PR TITLE
chore(ansible): add ulimit execution to setenv_caret.bash

### DIFF
--- a/ansible/roles/caret/templates/setenv_caret.bash.jinja2
+++ b/ansible/roles/caret/templates/setenv_caret.bash.jinja2
@@ -12,5 +12,5 @@ export LD_PRELOAD=$(readlink -f {{ WORKSPACE_ROOT}}/install/caret_trace/lib/libc
 # Execute ulimit command as below.
 # ulimit -n 16384
 
-# Add user application bulit with caret/rclcpp
+# Add user application built with caret/rclcpp
 # source /path/to/your/application/install/setup.bash

--- a/ansible/roles/caret/templates/setenv_caret.bash.jinja2
+++ b/ansible/roles/caret/templates/setenv_caret.bash.jinja2
@@ -6,5 +6,11 @@ source {{ WORKSPACE_ROOT }}/caret_topic_filter.bash
 
 export LD_PRELOAD=$(readlink -f {{ WORKSPACE_ROOT}}/install/caret_trace/lib/libcaret.so)
 
-# please add user application bulit with caret/rclcpp
+# If you want to apply CARET to a large application,
+# it is recommended to increase the maximum number of 
+# file descriptors to avoid data loss.
+# Execute ulimit command as below.
+# ulimit -n 16384
+
+# Add user application bulit with caret/rclcpp
 # source /path/to/your/application/install/setup.bash


### PR DESCRIPTION
Signed-off-by: Takayuki AKAMINE <takayuki.akamine@tier4.jp>

## Description
I want to add ulimit explanation to setenv_caret.bash.

After updating LTTng from 2.12 to 2.13, users have to mind the maximum number of file descriptor. I think that setenv_caret.bash must have some description for users to notice it. 

## Related links

https://tier4.github.io/CARET_doc/latest/recording/recording/#starting-lttng-session-manually
> You may find that size of recorded data is strangely smaller than expected after updating LTTng to 2.13 if you apply CARET to a large application like [Autoware](https://github.com/autowarefoundation/autoware) which has hundreds of nodes. You have to suspect that maximum number of file descriptors is not enough in the case. You can check the number with ulimit -n command. The default maximum number is 1024, but it is not enough for the large application. You can avoid this problem by enlarging the maximum number with executing the command; ulimit -n 65536.

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
