### PR TITLE
ci: fix build error by warnings

### DIFF
--- a/docker/build_autoware.dockerfile
+++ b/docker/build_autoware.dockerfile
@@ -65,7 +65,7 @@ RUN echo "===== Build Autoware ====="
 RUN cd autoware && \
     . /opt/ros/"$ROS_DISTRO"/setup.sh && \
     . /ros2_caret_ws/install/local_setup.sh && \
-    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=Off
+    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=Off -DCMAKE_CXX_FLAGS="-w"
 
 RUN echo "===== Verify Build ====="
 RUN cd autoware && \


### PR DESCRIPTION
Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

## Description

- This PR ignores  "all warnings being treated as errors" 
- Otherwise, build error occurs. e.g. https://github.com/tier4/caret/actions/runs/3998568645
    - It's caused by code in Autoware, and I'd like to ignore it to continue our test

## Related links

None

## Notes for reviewers

- For ` The PR has been properly tested.` you can check the following result
    - https://github.com/tier4/caret/actions/runs/4002305430

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
