### PR TITLE
fix(ansible): solve 'Unable to locate package ansible' error

### DIFF
--- a/setup_caret.sh
+++ b/setup_caret.sh
@@ -79,6 +79,7 @@ fi
 # TODO: To update Ansible 6.*
 ansible_version=$(pip3 list | grep -oP "^ansible\s+\K([0-9]+)" || true)
 if [ "$ansible_version" != "5" ]; then
+    sudo apt-get -y update
     sudo apt-get -y purge ansible
     sudo pip3 install -U "ansible==5.*"
 fi


### PR DESCRIPTION
Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

## Description

- `sudo apt-get update` is missed before `sudo apt-get -y purge ansible` , which causes `Unable to locate package ansible` error
    - The error happens when the environment is new (`apt update` is not yet processed or cache was removed, and both sudo and python3-pip is installed)
- This PR solves the error

## Related links

## Notes for reviewers

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
