### PR TITLE
ci: fix build with autoware

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ To get an overview of the project, read the [CARET document](https://tier4.githu
 
 ### Create a new issue
 
-When you create a new issue, [search FAQ in the document for known issues/solutions](https://tier4.github.io/CARET_doc/main/faq/).
+When you create a new issue, [search FAQ in the document for known issues/solutions](https://tier4.github.io/CARET_doc/main/faq/faq).
 
 CARET consists of multi repositories and <https://github.com/tier4/caret> is a meta repository. A new issue should be created in the meta repository, unless the issue is explicitly related to a certain repository.
 

--- a/.github/workflows/build_autoware.yaml
+++ b/.github/workflows/build_autoware.yaml
@@ -25,7 +25,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v4
         with:
-          context: ./docker
+          context: ./
           file: ./docker/build_autoware.dockerfile
           push: false
           tags: caret/caret_autoware:latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,4 @@
+```sh
+cd ros2_caret_ws
+docker image build -t caret/caret -f ./docker/build_autoware.dockerfile .
+```

--- a/docker/build_autoware.dockerfile
+++ b/docker/build_autoware.dockerfile
@@ -33,6 +33,7 @@ RUN echo "===== Setup Autoware ====="
 RUN git clone https://github.com/autowarefoundation/autoware.git && \
     cd autoware && \
     git checkout "$AUTOWARE_VERSION" && \
+    DEBIAN_FRONTEND=noninteractive apt install python3.10-venv -y && \
     ./setup-dev-env.sh -y --no-nvidia --no-cuda-drivers && \
     mkdir src && \
     vcs import src < autoware.repos && \

--- a/docker/build_autoware.dockerfile
+++ b/docker/build_autoware.dockerfile
@@ -15,10 +15,15 @@ ENV LANG en_US.UTF-8
 # Do not use cache
 ADD "https://www.random.org/sequences/?min=1&max=52&col=1&format=plain&rnd=new" /dev/null
 
+RUN echo "===== GET CARET ====="
+# RUN git clone https://github.com/tier4/caret.git ros2_caret_ws && \
+#     cd ros2_caret_ws && \
+#     git checkout "$CARET_VERSION"
+COPY ./ /ros2_caret_ws
+
 RUN echo "===== Setup CARET ====="
-RUN git clone https://github.com/tier4/caret.git ros2_caret_ws && \
-    cd ros2_caret_ws && \
-    git checkout "$CARET_VERSION" && \
+RUN cd ros2_caret_ws && \
+    rm -rf src build log install && \
     mkdir src && \
     vcs import src < caret.repos && \
     . /opt/ros/"$ROS_DISTRO"/setup.sh && \


### PR DESCRIPTION
## Description

- Fix CI (build_with_autoware) failure
- Use the current version (branch) of CARET instead of main branch
- (Fix  pre-commit-optional , broken link)

## Related links

- Before (failed): https://github.com/tier4/caret/actions/runs/4306007450
- After (passed): https://github.com/tier4/caret/actions/runs/4311911216

## Notes for reviewers

None

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
