### PR TITLE
chore: fix release commit message

### DIFF
--- a/release_script/release_caret.sh
+++ b/release_script/release_caret.sh
@@ -144,7 +144,7 @@ ${DRY_RUN} sed -i -e "s/RCL_HASH/${ROS_RCL_HASH}/g" "${ROOT_DIR}"/caret.repos
 ${DRY_RUN} sed -i -e "s/CARET_TAG/${TAG_ID}/g" "${ROOT_DIR}"/caret.repos
 
 ${DRY_RUN} git add "${ROOT_DIR}"/caret.repos
-${DRY_RUN} git commit -m "\"release(caret.repos): change version of sub repositories for ${TAG_ID}\""
+${DRY_RUN} git commit -m "release(caret.repos): change version of sub repositories for ${TAG_ID}"
 
 ${DRY_RUN} git tag "${TAG_ID}"
 


### PR DESCRIPTION
## Description

- Commit message for release has unnecessary double quotation. It violates commit message naming rule
  - ![image](https://github.com/tier4/caret/assets/105265012/f4116029-9530-4b3a-90ed-b2dd71b140ea)
- This PR removes it

## Related links

None


## Notes for reviewers

It would be great if you test it when you release CARET next time

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
