### PR TITLE
ci: fix Build with Autoware test

### DIFF
--- a/docker/build_autoware.dockerfile
+++ b/docker/build_autoware.dockerfile
@@ -5,7 +5,7 @@ ARG AUTOWARE_VERSION="main"
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        locales=2.35-0ubuntu3.1 \
+        locales=2.35-0ubuntu3.3 \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description

This PR fixes CI (Build with Autoware). It failed 2023/09/13 because locale package 2.35-0ubuntu3.1 cannot be installed. This PR update local version to be installed

- main as of 2023/09/13: https://github.com/tier4/caret/actions/runs/6175555552
- with this PR: https://github.com/tier4/caret/actions/runs/6178498060

## Related links

None

## Notes for reviewers

None

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
