### PR TITLE
fix: daemonize if lttng session is not running

### DIFF
--- a/ansible/roles/caret/templates/setenv_caret.bash.jinja2
+++ b/ansible/roles/caret/templates/setenv_caret.bash.jinja2
@@ -6,6 +6,12 @@ source {{ WORKSPACE_ROOT }}/caret_topic_filter.bash
 
 export LD_PRELOAD=$(readlink -f {{ WORKSPACE_ROOT}}/install/caret_trace/lib/libcaret.so)
 
+USERNAME=$(whoami)
+ps aux|grep lttng-sessiond | grep $USERNAME | grep -v grep > /dev/null
+if [ $? -ne 0 ]; then
+  lttng-sessiond --daemonize
+fi
+
 # If you want to apply CARET to a large application,
 # it is recommended to increase the maximum number of
 # file descriptors to avoid data loss.


### PR DESCRIPTION
## Description

setenv_caret.bash to daemonize if the lttng session is not started

## Related links

https://tier4.atlassian.net/browse/RT2-973

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
