### PR TITLE
ci: don't use cache to build with Autoware

### DIFF
--- a/.github/workflows/build_autoware.yaml
+++ b/.github/workflows/build_autoware.yaml
@@ -14,18 +14,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Update Docker image
-        run: docker pull osrf/ros:humble-desktop
-
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v5
-        with:
-          context: ./
-          file: ./docker/build_autoware.dockerfile
-          push: false
-          tags: caret/caret_autoware:latest
+      - name: Docker Build
+        run: |
+          docker pull osrf/ros:humble-desktop
+          docker image build --no-cache=true -t caret/caret_autoware:latest -f ./docker/build_autoware.dockerfile ./

--- a/docker/build_autoware.dockerfile
+++ b/docker/build_autoware.dockerfile
@@ -5,7 +5,7 @@ ARG AUTOWARE_VERSION="main"
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        locales=2.35-0ubuntu3.3 \
+        locales \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description

This PR fixes CI (Build with Autoware) failure by disabling cache for Docker.
Building Autoware failed even without CARET but a new PR fixes the error recently, but the new PR is not reflected in our CI due to cache. That's why CI kept failed.

## Related links

None

## Notes for reviewers

None

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
