### PR TITLE
fix(docker): ros2caret_usage

### DIFF
--- a/docker/build_autoware.dockerfile
+++ b/docker/build_autoware.dockerfile
@@ -83,4 +83,4 @@ RUN echo "===== Verify Build ====="
 RUN cd autoware && \
     . /opt/ros/"$ROS_DISTRO"/setup.sh && \
     . /ros2_caret_ws/install/local_setup.sh && \
-    ros2 caret check_caret_rclcpp --workspace ./
+    ros2 caret check_caret_rclcpp ./


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Fix usage of the `ros2caret` command.
Cahnged from `ros2 caret check_caret_rclcpp --workspace ./` to `ros2 caret check_caret_rclcpp ./`

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
- https://github.com/tier4/ros2caret/pull/129

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
