### PR TITLE
fix: the requirements.txt in caret is installed with user privileges.

### DIFF
--- a/ansible/roles/caret/tasks/main.yml
+++ b/ansible/roles/caret/tasks/main.yml
@@ -39,7 +39,7 @@
   pip:
     requirements: "{{ requirements_path }}"
     executable: pip3
-  become: true
+  become: false
   args:
     chdir: "{{ WORKSPACE_ROOT }}"
 

--- a/ansible/roles/caret_iron/tasks/main.yml
+++ b/ansible/roles/caret_iron/tasks/main.yml
@@ -39,7 +39,7 @@
   pip:
     requirements: "{{ requirements_path }}"
     executable: pip3
-  become: true
+  become: false
   args:
     chdir: "{{ WORKSPACE_ROOT }}"
 

--- a/ansible/roles/ros-tracing/tasks/main.yml
+++ b/ansible/roles/ros-tracing/tasks/main.yml
@@ -9,7 +9,7 @@
   pip:
     requirements: "{{ requirements_path }}"
     executable: pip3
-  become: true
+  become: false
   args:
     chdir: "{{ WORKSPACE_ROOT }}"
 

--- a/ansible/roles/visualizer/tasks/main.yml
+++ b/ansible/roles/visualizer/tasks/main.yml
@@ -11,6 +11,6 @@
     requirements: "{{ requirements_path }}"
     executable: pip3
     extra_args: --ignore-installed
-  become: true
+  become: false
   args:
     chdir: "{{ WORKSPACE_ROOT }}"

--- a/setup_caret.sh
+++ b/setup_caret.sh
@@ -122,8 +122,13 @@ fi
 # Run ansible
 if ansible-playbook "$SCRIPT_DIR/ansible/$PLAYBOOK" -e WORKSPACE_ROOT="$SCRIPT_DIR" "${options[@]}"; then
     echo -e "\e[32mCompleted.\e[0m"
-    exit 0
 else
     echo -e "\e[31mFailed.\e[0m"
     exit 1
 fi
+
+# Add PATH
+grep -Fxq "export PATH=\$PATH:$HOME/.local/bin" "$HOME/.bashrc" || {
+    echo "export PATH=\$PATH:$HOME/.local/bin" >> "$HOME/.bashrc"
+}
+exit 0

--- a/setup_caret.sh
+++ b/setup_caret.sh
@@ -129,6 +129,6 @@ fi
 
 # Add PATH
 grep -Fxq "export PATH=\$PATH:$HOME/.local/bin" "$HOME/.bashrc" || {
-    echo "export PATH=\$PATH:$HOME/.local/bin" >> "$HOME/.bashrc"
+    echo "export PATH=\$PATH:$HOME/.local/bin" >>"$HOME/.bashrc"
 }
 exit 0


### PR DESCRIPTION
## Description

The requirements.txt in caret is installed with user privileges.

## Related links

[https://tier4.atlassian.net/browse/RT2-1874](https://tier4.atlassian.net/browse/RT2-1874)

## Notes for reviewers

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
