### PR TITLE
fix: ansible update to version 6*

### DIFF
--- a/setup_caret.sh
+++ b/setup_caret.sh
@@ -96,12 +96,11 @@ fi
 
 # Run ansible if confirmed
 # Install ansible
-# TODO: To update Ansible 6.*
 ansible_version=$(pip3 list | grep -oP "^ansible\s+\K([0-9]+)" || true)
-if [ "$ansible_version" != "5" ]; then
+if [ "$ansible_version" != "6" ]; then
     sudo apt-get -y update
     sudo apt-get -y purge ansible
-    sudo pip3 install -U "ansible==5.*"
+    sudo pip3 install -U "ansible==6.*"
 fi
 
 # Set options


### PR DESCRIPTION
## Description

Increase the version of ansible to “6*” to match autoware.

## Related links

[https://tier4.atlassian.net/browse/RT2-1874](https://tier4.atlassian.net/browse/RT2-1874)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
