### PR TITLE
fix: add current value for LD_PRELOAD

### DIFF
--- a/ansible/roles/caret/templates/setenv_caret.bash.jinja2
+++ b/ansible/roles/caret/templates/setenv_caret.bash.jinja2
@@ -4,7 +4,7 @@ source /opt/ros/{{ rosdistro }}/setup.bash
 source {{ WORKSPACE_ROOT }}/install/local_setup.bash
 source {{ WORKSPACE_ROOT }}/caret_topic_filter.bash
 
-export LD_PRELOAD=$(readlink -f {{ WORKSPACE_ROOT}}/install/caret_trace/lib/libcaret.so)
+export LD_PRELOAD=$(readlink -f {{ WORKSPACE_ROOT}}/install/caret_trace/lib/libcaret.so):$LD_PRELOAD
 
 USERNAME=$(whoami)
 ps -axo user:32,command | grep lttng-sessiond | grep $USERNAME | grep -v grep > /dev/null

--- a/ansible/roles/caret_iron/templates/setenv_caret.bash.jinja2
+++ b/ansible/roles/caret_iron/templates/setenv_caret.bash.jinja2
@@ -4,7 +4,7 @@ source /opt/ros/{{ rosdistro }}/setup.bash
 source {{ WORKSPACE_ROOT }}/install/local_setup.bash
 source {{ WORKSPACE_ROOT }}/caret_topic_filter.bash
 
-export LD_PRELOAD=$(readlink -f {{ WORKSPACE_ROOT}}/install/caret_trace/lib/libcaret.so)
+export LD_PRELOAD=$(readlink -f {{ WORKSPACE_ROOT}}/install/caret_trace/lib/libcaret.so):$LD_PRELOAD
 
 USERNAME=$(whoami)
 ps -axo user:32,command | grep lttng-sessiond | grep $USERNAME | grep -v grep > /dev/null


### PR DESCRIPTION
## Description

This fixes to leave the existing values in the set part of `LD_PRELOAD`. 

## Related links

[Related Thread in Slack (TIER IV internal)](https://star4.slack.com/archives/C07FL8616EM/p1732776202743879?thread_ts=1732752446.741309&cid=C07FL8616EM)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
