### PR TITLE
chore: add topic_tools repo

### DIFF
--- a/caret.repos
+++ b/caret.repos
@@ -36,3 +36,7 @@ repositories:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
     version: releases/0.10.x
+  ros-tooling/topic_tools:  # To apply CARET for widely used pre-built packages
+    type: git
+    url: https://github.com/ros-tooling/topic_tools.git
+    version: 1.1.1

--- a/caret.repos
+++ b/caret.repos
@@ -32,11 +32,14 @@ repositories:
     type: git
     url: https://github.com/tier4/caret_common.git
     version: main
+
+  ### Optional packages. Apply CARET for widely used pre-built packages ###
+  ### Delete or change version depending on a target application ###
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
     version: releases/0.10.x
-  ros-tooling/topic_tools:  # To apply CARET for widely used pre-built packages
+  ros-tooling/topic_tools:
     type: git
     url: https://github.com/ros-tooling/topic_tools.git
     version: 1.1.1


### PR DESCRIPTION
## Description

- Background
  - [topic_tools](https://github.com/ros-tooling/topic_tools) is a widely used package
  - This package is installed by apt and a pre-built package, therefore an application using such package cannot be traced by CARET, especially path analysis doesn't work
- Changes
  - Build topic_tools along with CARET

## Related links

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT2-2211)

## Notes for reviewers

- This change is needed only for Humble, because an application no longer needs to be build with caret/rclcpp after Iron where trace points by CARET are implemented into ros/rclcpp
- I considered to separate repos file. For instance, topic_tools can be added into a new repo file named vendor.repos. However, I decided to aggregate them to make it simple and easy to use

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
