### PR TITLE
fix: add topic_tools to the caret release script

### DIFF
--- a/release_script/release_caret.sh
+++ b/release_script/release_caret.sh
@@ -49,6 +49,9 @@ ROS_RCL_REPOS="rcl"
 # cyclonedds
 CYCLONEDDS_REPOS="cyclonedds"
 
+# topic_tools
+TOPIC_TOOLS_REPOS="topic_tools"
+
 # variables
 DRY_RUN=
 TAG_ID=
@@ -146,6 +149,10 @@ ROS_RCL_HASH=$(get_hash_from_repository "${ROOT_DIR}"/${ROS_RCL_PATH})
 CYCLONEDDS_PATH="src/eclipse-cyclonedds/${CYCLONEDDS_REPOS}"
 CYCLONEDDS_HASH=$(get_hash_from_repository "${ROOT_DIR}"/${CYCLONEDDS_PATH})
 
+# get hash number from topic_tools
+TOPIC_TOOLS_PATH="src/ros-tooling/${TOPIC_TOOLS_REPOS}"
+TOPIC_TOOLS_HASH=$(get_hash_from_repository "${ROOT_DIR}"/${TOPIC_TOOLS_PATH})
+
 # checkout caret repository.
 ${DRY_RUN} git checkout -b rc/"${TAG_ID}"
 
@@ -155,6 +162,7 @@ ${DRY_RUN} sed -i -e "s/ROS_TRACING_HASH/${ROS_TRACING_HASH}/g" "${ROOT_DIR}"/ca
 ${DRY_RUN} sed -i -e "s/RCLCPP_HASH/${ROS_RCLCPP_HASH}/g" "${ROOT_DIR}"/caret.repos
 ${DRY_RUN} sed -i -e "s/RCL_HASH/${ROS_RCL_HASH}/g" "${ROOT_DIR}"/caret.repos
 ${DRY_RUN} sed -i -e "s/CYCLONEDDS_HASH/${CYCLONEDDS_HASH}/g" "${ROOT_DIR}"/caret.repos
+${DRY_RUN} sed -i -e "s/TOPIC_TOOLS_HASH/${TOPIC_TOOLS_HASH}/g" "${ROOT_DIR}"/caret.repos
 ${DRY_RUN} sed -i -e "s/CARET_TAG/${TAG_ID}/g" "${ROOT_DIR}"/caret.repos
 
 ${DRY_RUN} git add "${ROOT_DIR}"/caret.repos

--- a/release_script/template_caret.repos
+++ b/release_script/template_caret.repos
@@ -35,3 +35,7 @@ repositories:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
     version: CYCLONEDDS_HASH
+  ros-tooling/topic_tools:
+    type: git
+    url: https://github.com/ros-tooling/topic_tools.git
+    version: TOPIC_TOOLS_HASH


### PR DESCRIPTION
## Description

Modify the following release scripts to incorporate the topic_tools package into caret.
- release_script/release_caret.sh
- release_script/template_caret.repos

This modification is also incorporated into v0.6.2 tags.

## Related links

[https://github.com/tier4/caret/pull/211](https://github.com/tier4/caret/pull/211)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
