### PR TITLE
fix: rosdep update --include-eol-distros for iron

### DIFF
--- a/ansible/roles/caret_iron/tasks/main.yml
+++ b/ansible/roles/caret_iron/tasks/main.yml
@@ -16,7 +16,7 @@
   become: true
 
 - name: ROS2 (update rosdep)
-  command: rosdep update
+  command: rosdep update --include-eol-distros
   become: false
 
 - name: caret (rosdep install dependencies)


### PR DESCRIPTION
## Description

Iron is now unsupported in ros2. As a result, the rosdep update does not work on the iron version of caret and the setup fails.

## Related links

[https://tier4.atlassian.net/browse/RT2-2362](https://tier4.atlassian.net/browse/RT2-2362)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
