### PR TITLE
ci: ignore Agnocast

### DIFF
--- a/docker/build_autoware.dockerfile
+++ b/docker/build_autoware.dockerfile
@@ -42,6 +42,9 @@ RUN git clone https://github.com/autowarefoundation/autoware.git && \
 # install ros-humble-pacmod3-msgs manually because rosdep tries to install ros-galactic-pacmod3-msgs
 # remove gpg because build error happens in ad_api_visualizers for some reasons...
 
+# workaround: remove agnocast because CARET doesn't support Agnocast yet and Agnocast is not used by default
+RUN rm -rf autoware/src/middleware/external/agnocast
+
 # https://github.com/ament/ament_cmake/commit/799183ab9bcfd9b66df0de9b644abaf8c9b78e84
 RUN echo "===== Modify ament_cmake_auto as workaround ====="
 RUN cd /opt/ros/humble/share/ament_cmake_auto/cmake && \


### PR DESCRIPTION
## Description

- Agnocast has been introduced to Autoware. Agnocast is to be built but is not used by default
- However, CARET doesn't support Agnocast yet. It will be supported in a few months
- At the moment, Agnocast needs to be ignored to pass build

## Related links

None

## Notes for reviewers

- Before (build error happens when building Agnocast)
  - https://github.com/tier4/caret/actions/runs/14771035732/job/41471002491#step:3:12177
- After (build passed)
  - https://github.com/tier4/caret/actions/runs/14772014419

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
