### PR TITLE
ci: ignore agnocast_wrapper

### DIFF
--- a/docker/build_autoware.dockerfile
+++ b/docker/build_autoware.dockerfile
@@ -44,6 +44,7 @@ RUN git clone https://github.com/autowarefoundation/autoware.git && \
 
 # workaround: remove agnocast because CARET doesn't support Agnocast yet and Agnocast is not used by default
 RUN rm -rf autoware/src/middleware/external/agnocast
+RUN rm -rf autoware/src/universe/autoware_universe/common/autoware_agnocast_wrapper
 
 # https://github.com/ament/ament_cmake/commit/799183ab9bcfd9b66df0de9b644abaf8c9b78e84
 RUN echo "===== Modify ament_cmake_auto as workaround ====="


### PR DESCRIPTION
## Description

### Background

- Agnocast has been introduced to Autoware, but CARET doesn't support Agnocast yet. It causes build error
- Agnocast is not used by default, while it's part of the build

### Changes

- Ignore (remove) Agnocast related code before starting build

Related PR: https://github.com/tier4/caret/pull/216

## Related links

None

## Notes for reviewers

- Test result: https://github.com/tier4/caret/actions/runs/15896261297
- This change should be reverted when CARET officially support Agnocast


## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
