### PR TITLE
feat: setting environment variables for jazzy

### DIFF
--- a/docker/build_caret.dockerfile
+++ b/docker/build_caret.dockerfile
@@ -46,6 +46,7 @@ RUN cd ros2_caret_ws && \
         REPOS_FILE=caret_iron.repos ; \
     elif [ "$ROS_DISTRO" = "jazzy" ]; then \
         REPOS_FILE=caret_jazzy.repos ; \
+        export PIP_BREAK_SYSTEM_PACKAGES=1 ; \
     else \
         echo "Unsupported ROS_DISTRO: $ROS_DISTRO" && exit 1 ; \
     fi && \


### PR DESCRIPTION
## Description

Since the fix in PR228 now causes an error when using ci, I set the environment variables for jazzy.

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-102](https://tier4.atlassian.net/browse/SYSPERF-102)
[https://tier4.atlassian.net/browse/SYSPERF-107](https://tier4.atlassian.net/browse/SYSPERF-107)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
