### PR TITLE
feat: add --no-pip-install option to setup_caret.sh

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -6,6 +6,10 @@
       prompt: Would you like to install the require packages[y/n]
       default: y
       private: false
+    - name: pip_install
+      prompt: Would you like to run pip install[y/n]
+      default: y
+      private: false
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:

--- a/ansible/playbook_iron.yml
+++ b/ansible/playbook_iron.yml
@@ -6,6 +6,10 @@
       prompt: Would you like to install the require packages[y/n]
       default: y
       private: false
+    - name: pip_install
+      prompt: Would you like to run pip install[y/n]
+      default: y
+      private: false
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:

--- a/ansible/playbook_jazzy.yml
+++ b/ansible/playbook_jazzy.yml
@@ -6,6 +6,10 @@
       prompt: Would you like to install the require packages[y/n]
       default: y
       private: false
+    - name: pip_install
+      prompt: Would you like to run pip install[y/n]
+      default: y
+      private: false
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:

--- a/ansible/roles/caret/tasks/main.yml
+++ b/ansible/roles/caret/tasks/main.yml
@@ -41,6 +41,7 @@
   become: false
   args:
     chdir: "{{ WORKSPACE_ROOT }}"
+  when: pip_install | default('y') == 'y'
 
 - name: caret (make symbolic link to rclcpp)
   ansible.builtin.file:

--- a/ansible/roles/caret_iron/tasks/main.yml
+++ b/ansible/roles/caret_iron/tasks/main.yml
@@ -41,6 +41,7 @@
   become: false
   args:
     chdir: "{{ WORKSPACE_ROOT }}"
+  when: pip_install | default('y') == 'y'
 
 - name: caret (copy CARET setenv template as reference)
   ansible.builtin.template:

--- a/ansible/roles/caret_jazzy/tasks/main.yml
+++ b/ansible/roles/caret_jazzy/tasks/main.yml
@@ -42,6 +42,7 @@
   become: false
   args:
     chdir: "{{ WORKSPACE_ROOT }}"
+  when: pip_install | default('y') == 'y'
 
 - name: caret (copy CARET setenv template as reference)
   ansible.builtin.template:

--- a/ansible/roles/ros-tracing/tasks/main.yml
+++ b/ansible/roles/ros-tracing/tasks/main.yml
@@ -12,6 +12,7 @@
   become: false
   args:
     chdir: "{{ WORKSPACE_ROOT }}"
+  when: pip_install | default('y') == 'y'
 
 - name: Install ros-tracing
   apt:

--- a/ansible/roles/visualizer/tasks/main.yml
+++ b/ansible/roles/visualizer/tasks/main.yml
@@ -14,3 +14,4 @@
   become: false
   args:
     chdir: "{{ WORKSPACE_ROOT }}"
+  when: pip_install | default('y') == 'y'

--- a/setup_caret.sh
+++ b/setup_caret.sh
@@ -11,7 +11,7 @@ function show_usage() {
     echo "    -h or --help: show help message"
     echo "    -c or --no-interactive"
     echo "    -n or --no-package-install"
-    echo "    -p or --no-pip-install"
+    echo "    -p or --no-pip-install  (skip pip installs in ansible playbooks; ansible itself is still installed via pip as a prerequisite)"
     echo "    -d or --ros-distro"
     echo ""
     echo "Required for ROS 2 Jazzy (Ubuntu 24.04+):"

--- a/setup_caret.sh
+++ b/setup_caret.sh
@@ -11,6 +11,7 @@ function show_usage() {
     echo "    -h or --help: show help message"
     echo "    -c or --no-interactive"
     echo "    -n or --no-package-install"
+    echo "    -p or --no-pip-install"
     echo "    -d or --ros-distro"
     echo ""
     echo "Required for ROS 2 Jazzy (Ubuntu 24.04+):"
@@ -30,13 +31,14 @@ function validate_ros_distro() {
 }
 
 # parse command options.
-OPT=$(getopt -o nchd: -l no-interactive,no-package-install,help,ros-distro: -- "$@") # cSpell:ignore nchd
+OPT=$(getopt -o nphcd: -l no-interactive,no-package-install,no-pip-install,help,ros-distro: -- "$@") # cSpell:ignore nphcd
 
 eval set -- "$OPT"
 
 # Parse args
 noninteractive=0
 package_install=1
+pip_install=1
 ros_distro=humble
 
 while true; do
@@ -50,6 +52,10 @@ while true; do
         ;;
     -n | --no-package-install)
         package_install=0
+        shift
+        ;;
+    -p | --no-pip-install)
+        pip_install=0
         shift
         ;;
     -d | --ros-distro)
@@ -131,12 +137,22 @@ else
 fi
 
 # Set options
+declare -a options=()
+
 if [ $noninteractive -eq 0 ]; then
     options=("--ask-become-pass")
 fi
 
 if [ $package_install -eq 0 ]; then
-    options=("--extra-vars" "package_install=n")
+    options+=("--extra-vars" "package_install=n")
+elif [ $noninteractive -eq 1 ]; then
+    options+=("--extra-vars" "package_install=y")
+fi
+
+if [ $pip_install -eq 0 ]; then
+    options+=("--extra-vars" "pip_install=n")
+elif [ $noninteractive -eq 1 ]; then
+    options+=("--extra-vars" "pip_install=y")
 fi
 
 # Select playbook


### PR DESCRIPTION
## Summary

- Add `-p` / `--no-pip-install` option to `setup_caret.sh` to allow skipping pip install steps independently from other package installations
- Add `pip_install` variable to ansible playbooks (`vars_prompt`) so users are interactively asked whether to run pip install
- Add `when: pip_install | default('y') == 'y'` condition to pip install tasks in all four ansible roles (`caret`, `caret_iron`, `caret_jazzy`, `visualizer`)

## Motivation

Previously, pip install steps in the `caret`/`caret_iron`/`caret_jazzy` roles were always executed regardless of user intent. This change allows skipping pip installs independently — useful when pip packages are already installed or managed by another tool.

## Behavior by flag combination

| `-c` (non-interactive) | `-n` (no-package-install) | `-p` (no-pip-install) | `package_install` passed to ansible | `pip_install` passed to ansible |
|:---:|:---:|:---:|:---:|:---:|
| | | | prompted (`y` default) | prompted (`y` default) |
| | ✓ | | `n` | prompted (`y` default) |
| | | ✓ | prompted (`y` default) | `n` |
| | ✓ | ✓ | `n` | `n` |
| ✓ | | | `y` (suppresses prompt) | `y` (suppresses prompt) |
| ✓ | ✓ | | `n` | `y` |
| ✓ | | ✓ | `y` | `n` |
| ✓ | ✓ | ✓ | `n` | `n` |

### What each ansible variable controls

| Variable | `y` | `n` |
|:---|:---|:---|
| `package_install` | Run `lttng`, `ros-tracing`, `visualizer` roles | Skip those roles |
| `pip_install` | Run pip install tasks in all roles | Skip pip install tasks in all roles |

## Test plan

- [ ] Run `./setup_caret.sh` (interactive, no flags) — verify both prompts appear and `y` runs full install
- [ ] Run `./setup_caret.sh` (interactive, no flags) — answer `n` to pip install prompt — verify pip install tasks are skipped
- [ ] Run `./setup_caret.sh -p` — verify pip install tasks are skipped without prompt, all other tasks run normally
- [ ] Run `./setup_caret.sh -n` — verify `lttng`/`ros-tracing`/`visualizer` roles are skipped, pip install inside `caret` role still runs
- [ ] Run `./setup_caret.sh -n -p` — verify both package install roles and pip install tasks are skipped
- [ ] Run `./setup_caret.sh -c` — verify no prompts appear and full install runs (both `package_install=y` and `pip_install=y` passed via extra-vars)
- [ ] Run `./setup_caret.sh -c -p` — verify no prompts and pip install is skipped
- [ ] Run `./setup_caret.sh -c -n -p` — verify no prompts, no package install, no pip install
- [ ] Verify behavior is consistent across all three ROS distros (`humble`, `iron`, `jazzy`) via `-d` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)