### PR TITLE
chore: remove ros-tracing ansible role and add official trace packag…

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -18,6 +18,5 @@
 
   roles:
     - { role: lttng, tags: [lttng], when: package_install == 'y' }
-    - { role: ros-tracing, rosdistro: humble, tags: [ros-tracing], when: package_install == 'y' }
     - { role: visualizer, tags: [visualizer], when: package_install == 'y' }
     - { role: caret, rosdistro: humble, tags: [caret] }

--- a/ansible/playbook_iron.yml
+++ b/ansible/playbook_iron.yml
@@ -18,6 +18,5 @@
 
   roles:
     - { role: lttng, tags: [lttng], when: package_install == 'y' }
-    - { role: ros-tracing, rosdistro: iron, tags: [ros-tracing], when: package_install == 'y' }
     - { role: visualizer, tags: [visualizer], when: package_install == 'y' }
     - { role: caret_iron, rosdistro: iron, tags: [caret] }

--- a/ansible/playbook_jazzy.yml
+++ b/ansible/playbook_jazzy.yml
@@ -18,6 +18,5 @@
 
   roles:
     - { role: lttng, tags: [lttng], when: package_install == 'y' }
-    - { role: ros-tracing, rosdistro: jazzy, tags: [ros-tracing], when: package_install == 'y' }
     - { role: visualizer, tags: [visualizer], when: package_install == 'y' }
     - { role: caret_jazzy, rosdistro: jazzy, tags: [caret] }

--- a/ansible/roles/caret/tasks/main.yml
+++ b/ansible/roles/caret/tasks/main.yml
@@ -32,6 +32,9 @@
       - ros-{{ rosdistro }}-performance-test-fixture
       - ros-{{ rosdistro }}-mimick-vendor
       - ros-{{ rosdistro }}-test-msgs
+      - ros-{{ rosdistro }}-ros2trace
+      - ros-{{ rosdistro }}-ros2trace-analysis
+      - ros-{{ rosdistro }}-tracetools
   become: true
 
 - name: caret (install python module)

--- a/ansible/roles/caret_iron/tasks/main.yml
+++ b/ansible/roles/caret_iron/tasks/main.yml
@@ -32,6 +32,9 @@
       - ros-{{ rosdistro }}-performance-test-fixture
       - ros-{{ rosdistro }}-mimick-vendor
       - ros-{{ rosdistro }}-test-msgs
+      - ros-{{ rosdistro }}-ros2trace
+      - ros-{{ rosdistro }}-ros2trace-analysis
+      - ros-{{ rosdistro }}-tracetools
   become: true
 
 - name: caret (install python module)

--- a/ansible/roles/caret_jazzy/tasks/main.yml
+++ b/ansible/roles/caret_jazzy/tasks/main.yml
@@ -33,6 +33,9 @@
       - ros-{{ rosdistro }}-performance-test-fixture
       - ros-{{ rosdistro }}-mimick-vendor
       - ros-{{ rosdistro }}-test-msgs
+      - ros-{{ rosdistro }}-ros2trace
+      - ros-{{ rosdistro }}-ros2trace-analysis
+      - ros-{{ rosdistro }}-tracetools
   become: true
 
 - name: caret (install python module)

--- a/setup_caret.sh
+++ b/setup_caret.sh
@@ -174,7 +174,7 @@ fi
 # Ensure symbol visibility in CycloneDDS by comment out the hidden preset
 CHECK_FILE="src/eclipse-cyclonedds/cyclonedds/src/core/CMakeLists.txt"
 if [ -f "$CHECK_FILE" ]; then
-###    sed -i "s/^set_property(TARGET ddsc PROPERTY C_VISIBILITY_PRESET hidden)/\# &/" "$CHECK_FILE"
+    ###    sed -i "s/^set_property(TARGET ddsc PROPERTY C_VISIBILITY_PRESET hidden)/\# &/" "$CHECK_FILE"
     echo "CycloneDDS configuration checked: Symbols unhidden successfully."
 else
     echo "Error: CycloneDDS source not found. Did you run 'vcs import'?"

--- a/setup_caret.sh
+++ b/setup_caret.sh
@@ -174,7 +174,7 @@ fi
 # Ensure symbol visibility in CycloneDDS by comment out the hidden preset
 CHECK_FILE="src/eclipse-cyclonedds/cyclonedds/src/core/CMakeLists.txt"
 if [ -f "$CHECK_FILE" ]; then
-    sed -i "s/^set_property(TARGET ddsc PROPERTY C_VISIBILITY_PRESET hidden)/\# &/" "$CHECK_FILE"
+###    sed -i "s/^set_property(TARGET ddsc PROPERTY C_VISIBILITY_PRESET hidden)/\# &/" "$CHECK_FILE"
     echo "CycloneDDS configuration checked: Symbols unhidden successfully."
 else
     echo "Error: CycloneDDS source not found. Did you run 'vcs import'?"


### PR DESCRIPTION
## Description

This PR removes the redundant custom `ros-tracing` Ansible role across all target ROS 2 distributions (Humble/Iron/Jazzy) and replaces it by adding official ROS trace packages 

- ros-${rosdistro}-ros2trace, 
- ros-${rosdistro}-ros2trace-analysis
- ros-${rosdistro}-tracetools

directly to the apt dependencies in the caret roles.

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-131](https://tier4.atlassian.net/browse/SYSPERF-131)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
