### PR TITLE
build: remove redundant CycloneDDS package dependency from build environment

### DIFF
--- a/caret.repos
+++ b/caret.repos
@@ -35,10 +35,6 @@ repositories:
 
   ### Optional packages. Apply CARET for widely used pre-built packages ###
   ### Delete or change version depending on a target application ###
-  eclipse-cyclonedds/cyclonedds:
-    type: git
-    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: releases/0.10.x
   ros-tooling/topic_tools:
     type: git
     url: https://github.com/ros-tooling/topic_tools.git

--- a/caret_jazzy.repos
+++ b/caret_jazzy.repos
@@ -20,7 +20,3 @@ repositories:
     type: git
     url: https://github.com/tier4/caret_common.git
     version: main
-  eclipse-cyclonedds/cyclonedds:
-    type: git
-    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: releases/0.10.x

--- a/release_script/template_caret_jazzy.repos
+++ b/release_script/template_caret_jazzy.repos
@@ -19,7 +19,3 @@ repositories:
     type: git
     url: https://github.com/tier4/caret_common.git
     version: CARET_TAG
-  eclipse-cyclonedds/cyclonedds:
-    type: git
-    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: CYCLONEDDS_HASH

--- a/release_script/template_caret_jazzy.repos
+++ b/release_script/template_caret_jazzy.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/tier4/caret_common.git
     version: CARET_TAG
+  eclipse-cyclonedds/cyclonedds:
+    type: git
+    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+    version: CYCLONEDDS_HASH

--- a/setup_caret.sh
+++ b/setup_caret.sh
@@ -169,16 +169,6 @@ else
     exit 1
 fi
 
-# Ensure symbol visibility in CycloneDDS by comment out the hidden preset
-CHECK_FILE="src/eclipse-cyclonedds/cyclonedds/src/core/CMakeLists.txt"
-if [ -f "$CHECK_FILE" ]; then
-    sed -i "s/^set_property(TARGET ddsc PROPERTY C_VISIBILITY_PRESET hidden)/\# &/" "$CHECK_FILE"
-    echo "CycloneDDS configuration checked: Symbols unhidden successfully."
-else
-    echo "Error: CycloneDDS source not found. Did you run 'vcs import'?"
-    exit 1
-fi
-
 # Add PATH
 grep -Fxq "export PATH=\$PATH:$HOME/.local/bin" "$HOME/.bashrc" || {
     echo "export PATH=\$PATH:$HOME/.local/bin" >>"$HOME/.bashrc"


### PR DESCRIPTION
## Description

In alignment with the refactoring in `caret_trace` to eliminate internal CycloneDDS source bundling, this PR cleans up the build environment generation configurations by removing the now obsolete internal CycloneDDS package dependencies.

- Removed internal CycloneDDS source packages from the build environment generation targets.
- Migrated to a clean architecture that relies natively on the system-installed CycloneDDS.

This PR must be merged and verified in conjunction with the corresponding `caret_trace` PR [(https://github.com/tier4/caret_trace/pull/328)](https://github.com/tier4/caret_trace/pull/328).

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-126](https://tier4.atlassian.net/browse/SYSPERF-126)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
