### PR TITLE
fix: restore CycloneDDS symbol visibility configuration in setup script

### DIFF
--- a/setup_caret.sh
+++ b/setup_caret.sh
@@ -174,7 +174,7 @@ fi
 # Ensure symbol visibility in CycloneDDS by comment out the hidden preset
 CHECK_FILE="src/eclipse-cyclonedds/cyclonedds/src/core/CMakeLists.txt"
 if [ -f "$CHECK_FILE" ]; then
-    ###    sed -i "s/^set_property(TARGET ddsc PROPERTY C_VISIBILITY_PRESET hidden)/\# &/" "$CHECK_FILE"
+    sed -i "s/^set_property(TARGET ddsc PROPERTY C_VISIBILITY_PRESET hidden)/\# &/" "$CHECK_FILE"
     echo "CycloneDDS configuration checked: Symbols unhidden successfully."
 else
     echo "Error: CycloneDDS source not found. Did you run 'vcs import'?"


### PR DESCRIPTION
## Description

This pull request fixes an issue where the `sed` command in the setup script, which ensures symbol visibility for CycloneDDS, was accidentally commented out in PR#233.

## Related links

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
