### PR TITLE
fix: run rosdep update as root in caret_jazzy ansible role

### DIFF
--- a/ansible/roles/caret_jazzy/tasks/main.yml
+++ b/ansible/roles/caret_jazzy/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: ROS 2 (update rosdep)
   command: rosdep update
-  become: false
+  become: true
 
 - name: caret (rosdep install dependencies)
   shell: |


### PR DESCRIPTION
## Summary

- Change `become` for `rosdep update` from `false` to `true`
- `rosdep install` requires sudo privileges because it internally calls `apt-get` to install system packages, so it runs as root (`become: true`)
- When `rosdep update` runs as a non-root user (`become: false`), the cache is written to `~/.ros/rosdep/`, but `rosdep install` running as root looks for the cache at `/root/.ros/rosdep/`, causing it to fail with "rosdep has not been initialized"
- Running both tasks as root resolves the cache path mismatch

## Test plan

- [x] Confirm `setup_caret.sh -d jazzy` completes without error on a fresh run

🤖 Generated with [Claude Code](https://claude.com/claude-code)