### PR TITLE
fix: update caret apt dependencies and remove redundant ros2trace packages

### DIFF
--- a/ansible/roles/caret/tasks/main.yml
+++ b/ansible/roles/caret/tasks/main.yml
@@ -32,9 +32,7 @@
       - ros-{{ rosdistro }}-performance-test-fixture
       - ros-{{ rosdistro }}-mimick-vendor
       - ros-{{ rosdistro }}-test-msgs
-      - ros-{{ rosdistro }}-ros2trace
-      - ros-{{ rosdistro }}-ros2trace-analysis
-      - ros-{{ rosdistro }}-tracetools
+      - ros-build-essential
   become: true
 
 - name: caret (install python module)

--- a/ansible/roles/caret_iron/tasks/main.yml
+++ b/ansible/roles/caret_iron/tasks/main.yml
@@ -32,9 +32,7 @@
       - ros-{{ rosdistro }}-performance-test-fixture
       - ros-{{ rosdistro }}-mimick-vendor
       - ros-{{ rosdistro }}-test-msgs
-      - ros-{{ rosdistro }}-ros2trace
-      - ros-{{ rosdistro }}-ros2trace-analysis
-      - ros-{{ rosdistro }}-tracetools
+      - ros-build-essential
   become: true
 
 - name: caret (install python module)

--- a/ansible/roles/caret_jazzy/tasks/main.yml
+++ b/ansible/roles/caret_jazzy/tasks/main.yml
@@ -33,9 +33,7 @@
       - ros-{{ rosdistro }}-performance-test-fixture
       - ros-{{ rosdistro }}-mimick-vendor
       - ros-{{ rosdistro }}-test-msgs
-      - ros-{{ rosdistro }}-ros2trace
-      - ros-{{ rosdistro }}-ros2trace-analysis
-      - ros-{{ rosdistro }}-tracetools
+      - ros-build-essential
   become: true
 
 - name: caret (install python module)


### PR DESCRIPTION
## Description

Update caret apt dependencies and remove redundant ros2trace packages.

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-131](https://tier4.atlassian.net/browse/SYSPERF-131)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
