### PR TITLE
fix: release script at dry-run

### DIFF
--- a/release_script/release_caret.sh
+++ b/release_script/release_caret.sh
@@ -167,15 +167,15 @@ for TEMPLATE in "${SCRIPT_DIR}"/template_caret_*.repos; do
 
         if [ -d "$dir" ]; then
             hash=$(git -C "$dir" rev-parse HEAD)
-	    sed -i -e "s/${placeholder}/${hash}/g" "${TARGET_FILE}"
+            sed -i -e "s/${placeholder}/${hash}/g" "${TARGET_FILE}"
         fi
     done
 
     if [ "${DRY_RUN}" == "echo" ]; then
         ${DRY_RUN} "--------------------------------------------------------"
-	${DRY_RUN} "Dry-run: Previewing generated ${OUTPUT} from ${FILENAME}"
+        ${DRY_RUN} "Dry-run: Previewing generated ${OUTPUT} from ${FILENAME}"
         ${DRY_RUN} "--------------------------------------------------------"
-	cat "${TARGET_FILE}"
+        cat "${TARGET_FILE}"
         rm "${TARGET_FILE}"
     else
         git add "${OUTPUT}"

--- a/release_script/release_caret.sh
+++ b/release_script/release_caret.sh
@@ -139,9 +139,17 @@ for TEMPLATE in "${SCRIPT_DIR}"/template_caret_*.repos; do
     else
         OUTPUT="${ROOT_DIR}/caret_${TEMPLATE_DISTRO}.repos"
     fi
-    cp "${TEMPLATE}" "${OUTPUT}"
 
-    sed -i -e "s/CARET_TAG/${TAG_ID}/g" "${OUTPUT}"
+    # if dry-run, use temp file
+    if [ "${DRY_RUN}" == "echo" ]; then
+        TARGET_FILE=$(mktemp)
+        cp "${TEMPLATE}" "${TARGET_FILE}"
+    else
+        TARGET_FILE="${OUTPUT}"
+        cp "${TEMPLATE}" "${TARGET_FILE}"
+    fi
+
+    sed -i -e "s/CARET_TAG/${TAG_ID}/g" "${TARGET_FILE}"
 
     declare -A MAP=(
         ["ros2/rcl"]="RCL_HASH"
@@ -159,21 +167,22 @@ for TEMPLATE in "${SCRIPT_DIR}"/template_caret_*.repos; do
 
         if [ -d "$dir" ]; then
             hash=$(git -C "$dir" rev-parse HEAD)
-            sed -i -e "s/${placeholder}/${hash}/g" "${OUTPUT}"
+	    sed -i -e "s/${placeholder}/${hash}/g" "${TARGET_FILE}"
         fi
     done
 
     if [ "${DRY_RUN}" == "echo" ]; then
         ${DRY_RUN} "--------------------------------------------------------"
-        ${DRY_RUN} "Generating ${OUTPUT} from ${FILENAME} (Dry-run mode)..."
+	${DRY_RUN} "Dry-run: Previewing generated ${OUTPUT} from ${FILENAME}"
         ${DRY_RUN} "--------------------------------------------------------"
-        cat "${OUTPUT}"
+	cat "${TARGET_FILE}"
+        rm "${TARGET_FILE}"
     else
         git add "${OUTPUT}"
     fi
 done
 
-${DRY_RUN} git commit -m "release(${OUTPUT}): update versions for ${TAG_ID}"
+${DRY_RUN} git commit -m "release(repos): change version of sub repositories for ${TAG_ID}"
 ${DRY_RUN} git tag "${TAG_ID}"
 
 if [ "${PUSH_REMOTE}" == "true" ]; then


### PR DESCRIPTION
## Description

This PR fixes an issue where the release script accidentally overwrites local files during a dry-run.

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-133](https://tier4.atlassian.net/browse/SYSPERF-133)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
