### PR TITLE
fix(ansible): fix bokeh rendering issue by pre-cleaning metadata and updating pip option

### DIFF
--- a/ansible/roles/visualizer/tasks/main.yml
+++ b/ansible/roles/visualizer/tasks/main.yml
@@ -6,6 +6,7 @@
     update_cache: true
   become: true
 
+# cspell:ignore fileglob
 - name: Pre-clean bokeh directory and metadata to prevent nested installation
   file:
     path: "{{ item }}"

--- a/ansible/roles/visualizer/tasks/main.yml
+++ b/ansible/roles/visualizer/tasks/main.yml
@@ -6,11 +6,19 @@
     update_cache: true
   become: true
 
+- name: Pre-clean bokeh directory and metadata to prevent nested installation
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_fileglob:
+    - "{{ ansible_env.HOME }}/.local/lib/python3.10/site-packages/bokeh*"
+  become: false
+
 - name: Install caret dependent packages
   pip:
     requirements: "{{ requirements_path }}"
     executable: pip3
-    extra_args: --ignore-installed
+    extra_args: --force-reinstall
   become: false
   args:
     chdir: "{{ WORKSPACE_ROOT }}"


### PR DESCRIPTION
## Description

Fixes an issue where Bokeh reports (HTML) generated by CARET fail to render and display a blank page in web browsers under certain conditions.

### Cause
Due to the usage of the `--ignore-installed` option in the Ansible `pip` task, old Bokeh metadata directories (`.dist-info`) remained in a nested or duplicate state. As a result, the browser incorrectly loaded outdated BokehJS assets (e.g., loading JS version 3.6.3 even though the Python package was updated to 3.8.2), leading to a JavaScript crash during rendering.

### Changes
- **Update pip installation options**: Changed `extra_args` from `--ignore-installed` to `--force-reinstall` to ensure a clean installation and prevent dependency mismatches.
- **Add metadata pre-cleaning step**: Added an Ansible task to physically remove any existing `bokeh*` directories and metadata from the target environment immediately before installation.

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-140](https://tier4.atlassian.net/browse/SYSPERF-140)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
