### PR TITLE
fix: fix bokeh rendering issue

### DIFF
--- a/ansible/roles/visualizer/tasks/main.yml
+++ b/ansible/roles/visualizer/tasks/main.yml
@@ -6,6 +6,21 @@
     update_cache: true
   become: true
 
+- name: Find bokeh directories
+  find:
+    paths: "{{ ansible_env.HOME }}/.local/lib"
+    patterns: "*bokeh*"
+    file_type: directory
+    recurse: true
+  register: bokeh_dirs
+
+- name: Remove found bokeh directories
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ bokeh_dirs.files }}"
+  become: false
+
 - name: Install caret dependent packages
   pip:
     requirements: "{{ requirements_path }}"


### PR DESCRIPTION
## Description

Following the revert (#246) of PR #242, this PR reapplies only the necessary fixes.
It pre-cleans the bokeh directory under .local/lib in the user's local environment to prevent a nested installation.
Added tasks to find and remove existing bokeh directories in "ansible/roles/visualizer/tasks/main.yml".

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-140](https://tier4.atlassian.net/browse/SYSPERF-140)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
